### PR TITLE
Bug Fix For PNG With Alpha Channel

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -86,7 +86,7 @@ function getTensorFromImage(imageFile) {
     return null;
   }
   const data = fs.readFileSync(imageFile);
-  const bufferT = tf.node.decodeImage(data);
+  const bufferT = tf.node.decodeImage(data, 3);
   const expandedT = tf.expandDims(bufferT, 0);
   const imageT = tf.cast(expandedT, 'float32');
   imageT['file'] = imageFile;


### PR DESCRIPTION
I'm running this on over 200,000 images. I ran into a slight problem with the size of the tensor having 4 channels instead of 3, the proposed fix will correct that and only use 3 channels when loading the png image. Tested it and it is working for me now.